### PR TITLE
Remove Google Analytics

### DIFF
--- a/src/v2/layouts/layout.html
+++ b/src/v2/layouts/layout.html
@@ -130,16 +130,6 @@
     </footer>
 
     <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90971004-4', 'auto');
-  ga('send', 'pageview');
-    </script>
-
-    <script>
       ((window.gitter = {}).chat = {}).options = {
         room: 'os-js/OS.js'
       };

--- a/src/v3/_layouts/website/page.html
+++ b/src/v3/_layouts/website/page.html
@@ -26,14 +26,6 @@
 
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-90971004-4', 'auto');
-    ga('send', 'pageview');
-
     ((window.gitter = {}).chat = {}).options = {
       room: 'os-js/OS.js'
     };


### PR DESCRIPTION
Google Analytics: can we replace it?

Perhaps something FOSS, like: [Plausible](https://plausible.io), [Fathom](https://usefathom.com), [Matomo](https://matomo.org) or [Freshlytics](https://freshlytics.gitbook.io/docs/) would be better here.

A lot of mainstream browsers block Google's analytics plugins.

In 2017, a survey discovered that over 40% of people used ad-blockers. This number has risen dramatically in the last three years. This will, of course, create a considerable drop in accurate analytical data. 

Especially considering the technical nature of this project, that number may be even *greater.*

As ad-blockers continue to become more and more relevant in the years to come, this number is only expected to rise.

As such, I'd like to recommend [some FOSS alternatives](https://switching.software/replace/google-analytics), which *don't* get blocked. These solutions are not harmful to user privacy, either. *It's a win win.*

---

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/

Anyway, can't wait to see what happens! :stuck_out_tongue: 