### PR TITLE
osjs-monster-adapter

### DIFF
--- a/src/v3/resource/contrib/README.md
+++ b/src/v3/resource/contrib/README.md
@@ -29,6 +29,7 @@ If you want to submit your contribution, contact me by email, join the [Gitter](
 ## Filesystem
 
 * https://github.com/SpaceboyRoss01/osjs-devices-adapter - Adds all hardware devices to a root mountpoint
+* https://github.com/BurnaSmartLab/osjs-monster-adapter - An Adapter for os.js to work with swift saio object storage.
 
 ## Community
 

--- a/src/v3/resource/contrib/README.md
+++ b/src/v3/resource/contrib/README.md
@@ -29,7 +29,7 @@ If you want to submit your contribution, contact me by email, join the [Gitter](
 ## Filesystem
 
 * https://github.com/SpaceboyRoss01/osjs-devices-adapter - Adds all hardware devices to a root mountpoint
-* https://github.com/BurnaSmartLab/osjs-monster-adapter - An Adapter for os.js to work with swift saio object storage.
+* https://github.com/BurnaSmartLab/osjs-monster-adapter - Swift saio object storage VFS adapter 
 
 ## Community
 

--- a/src/v3/resource/contrib/README.md
+++ b/src/v3/resource/contrib/README.md
@@ -29,7 +29,7 @@ If you want to submit your contribution, contact me by email, join the [Gitter](
 ## Filesystem
 
 * https://github.com/SpaceboyRoss01/osjs-devices-adapter - Adds all hardware devices to a root mountpoint
-* https://github.com/BurnaSmartLab/osjs-monster-adapter - Swift saio object storage VFS adapter 
+* https://github.com/BurnaSmartLab/osjs-monster-adapter - OpenStack Swift object storage VFS adapter 
 
 ## Community
 


### PR DESCRIPTION
Add adapter github address in README.md

We have developed osjs-monster-adapter package for OS.js. 
https://www.npmjs.com/package/@burna/osjs-monster-adapter
https://github.com/BurnaSmartLab/osjs-monster-adapter

We want our package included to OS.js as an adapter such as webdav or FTP.